### PR TITLE
Email to Public Email in the mailto section.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
 <nav id="main-nav">{{ partial "navigation.html" . }}</nav>
 <nav id="sub-nav">
 	<div class="social">
-		{{ if $.Site.Author.email }}
+		{{ if $.Site.Author.public_email }}
 			<a class="email" href='mailto:{{ $.Site.Author.email }}' title="Email">Email</a>
 		{{ end }}
 		{{ if $.Site.Params.facebook_user }}


### PR DESCRIPTION
Some people may not want to display their emails publicly but want to show their gravatar. Using email for gravatar and public_email for showing mailto link will solve this problem.